### PR TITLE
Create chat gpt sidebar extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# ai-extention
+# ChatGPT Side Panel Chrome Extension
+
+Interact with ChatGPT from a Chrome side panel and capture screenshots to include in your prompts.
+
+## Features
+- Side panel UI with chat history
+- Uses your OpenAI API key (stored locally)
+- Capture current tab screenshot and attach to the next message
+- Keyboard shortcut to open the side panel (Ctrl+Shift+Y / Cmd+Shift+Y)
+
+## Install (Developer Mode)
+1. Build not required. Load the folder directly.
+2. Open Chrome → Settings → Extensions → enable Developer mode.
+3. Click "Load unpacked" and select the `extension` folder in this repo.
+4. Pin the extension if desired, then click it to open the side panel or use the shortcut.
+
+## Setup API Key
+1. In the side panel, click the gear icon or go to the extension's Options page.
+2. Paste your OpenAI API key (starts with `sk-...`).
+3. Save. The key is stored via `chrome.storage.local` in your browser.
+
+## Usage
+- Open side panel via toolbar icon or "Ctrl+Shift+Y" (macOS: "Cmd+Shift+Y").
+- Type a prompt and press Enter to send (Shift+Enter for newline).
+- Click the camera button to capture a screenshot; it will attach to your next message.
+
+## Files
+- `extension/manifest.json` — MV3 manifest
+- `extension/service_worker.js` — background service worker and command handler
+- `extension/sidepanel.html|css|js` — side panel UI and chat logic
+- `extension/options.html|css|js` — settings page for the OpenAI API key
+
+## Notes
+- Screenshot capture uses `chrome.tabs.captureVisibleTab`. Granting `activeTab` permission allows capture of the current tab. Some pages (e.g., Chrome Web Store, chrome:// URLs) cannot be captured due to browser restrictions.
+- API calls are made directly to `https://api.openai.com/v1/chat/completions` using model `gpt-4o-mini`. You can change the model in `sidepanel.js`.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,35 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Side Panel + Screenshots",
+  "description": "Talk to ChatGPT in a side panel and capture screenshots of the current tab.",
+  "version": "0.1.0",
+  "permissions": [
+    "storage",
+    "tabs",
+    "sidePanel",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "https://api.openai.com/*"
+  ],
+  "background": {
+    "service_worker": "service_worker.js",
+    "type": "module"
+  },
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
+  "action": {
+    "default_title": "Open ChatGPT Side Panel"
+  },
+  "options_page": "options.html",
+  "commands": {
+    "open-side-panel": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y",
+        "mac": "Command+Shift+Y"
+      },
+      "description": "Open ChatGPT side panel"
+    }
+  }
+}

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,25 @@
+:root {
+  --bg: #0b0b0c;
+  --bg-elev: #121214;
+  --text: #e7e7ea;
+  --muted: #a3a3ad;
+  --border: #26262b;
+  --primary: #10a37f;
+}
+
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+.wrap { max-width: 640px; margin: 40px auto; padding: 0 16px; }
+h1 { margin: 0 0 16px; }
+.field { display: grid; gap: 6px; margin-bottom: 12px; }
+input { background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
+.actions { display: flex; gap: 8px; }
+button { background: var(--primary); color: white; border: none; border-radius: 8px; padding: 8px 12px; cursor: pointer; }
+button.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+.hint { color: var(--muted); font-size: 12px; margin-top: 12px; }
+

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ChatGPT Extension Settings</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Settings</h1>
+      <label class="field">
+        <span>OpenAI API Key</span>
+        <input id="apiKey" type="password" placeholder="sk-..." />
+      </label>
+      <div class="actions">
+        <button id="saveBtn">Save</button>
+        <button id="clearBtn" class="secondary">Clear</button>
+      </div>
+      <p class="hint">Your key is stored locally via chrome.storage and never leaves your browser except requests sent directly to OpenAI.</p>
+    </div>
+    <script src="options.js" type="module"></script>
+  </body>
+  </html>
+

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,25 @@
+const apiKeyEl = document.getElementById('apiKey');
+const saveBtn = document.getElementById('saveBtn');
+const clearBtn = document.getElementById('clearBtn');
+
+async function load() {
+  const { openai_api_key } = await chrome.storage.local.get({ openai_api_key: '' });
+  apiKeyEl.value = openai_api_key || '';
+}
+
+async function save() {
+  const key = apiKeyEl.value.trim();
+  await chrome.storage.local.set({ openai_api_key: key });
+  alert('Saved');
+}
+
+async function clearKey() {
+  await chrome.storage.local.remove(['openai_api_key']);
+  apiKeyEl.value = '';
+  alert('Cleared');
+}
+
+saveBtn.addEventListener('click', save);
+clearBtn.addEventListener('click', clearKey);
+load();
+

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -1,0 +1,22 @@
+// Background service worker for the MV3 extension
+
+chrome.runtime.onInstalled.addListener(() => {
+  if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
+    chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+  }
+});
+
+chrome.commands.onCommand.addListener(async (command) => {
+  if (command !== 'open-side-panel') return;
+  try {
+    const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (activeTab && typeof activeTab.windowId === 'number') {
+      await chrome.sidePanel.open({ windowId: activeTab.windowId });
+    } else {
+      await chrome.sidePanel.open({});
+    }
+  } catch (error) {
+    // no-op: opening may fail if side panel unsupported in current context
+  }
+});
+

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -1,0 +1,70 @@
+:root {
+  --bg: #0b0b0c;
+  --bg-elev: #121214;
+  --text: #e7e7ea;
+  --muted: #a3a3ad;
+  --border: #26262b;
+  --primary: #10a37f;
+}
+
+* { box-sizing: border-box; }
+
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+
+#app { display: flex; flex-direction: column; height: 100vh; }
+
+.sp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+}
+.sp-title { font-weight: 600; }
+.sp-actions { display: flex; gap: 6px; }
+.sp-actions button {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.sp-actions button:hover { border-color: var(--muted); }
+
+.banner { display: flex; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border); background: #1a1a1f; align-items: center; }
+.banner button { background: var(--primary); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
+.hidden { display: none !important; }
+
+.messages {
+  flex: 1;
+  overflow: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.msg { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: var(--bg-elev); }
+.msg.assistant { border-color: #224c41; }
+.msg .role { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+.msg .content { white-space: pre-wrap; }
+.msg img.attachment { max-width: 100%; border-radius: 8px; border: 1px solid var(--border); margin-top: 8px; }
+
+.composer { border-top: 1px solid var(--border); background: var(--bg-elev); padding: 10px; display: grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; gap: 8px; }
+.composer #attachmentPreview { grid-column: 1 / -1; }
+.composer textarea { width: 100%; resize: none; background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; min-height: 40px; }
+.composer .composer-actions { display: flex; align-items: center; gap: 8px; }
+.composer button.primary { background: var(--primary); border: none; color: white; padding: 8px 12px; border-radius: 8px; cursor: pointer; }
+.composer button.primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.attachment { display: flex; gap: 8px; align-items: center; }
+.attachment img { max-width: 120px; border: 1px solid var(--border); border-radius: 8px; }
+.attachment .remove { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 4px 6px; cursor: pointer; }
+

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ChatGPT Side Panel</title>
+    <link rel="stylesheet" href="sidepanel.css" />
+  </head>
+  <body>
+    <div id="app">
+      <header class="sp-header">
+        <div class="sp-title">ChatGPT</div>
+        <div class="sp-actions">
+          <button id="screenshotBtn" title="Capture screenshot">📸</button>
+          <button id="openOptionsBtn" title="Open settings">⚙️</button>
+        </div>
+      </header>
+
+      <section id="apiKeyBanner" class="banner hidden">
+        <div>Set your OpenAI API key in Settings to start chatting.</div>
+        <button id="bannerOpenOptionsBtn">Open Settings</button>
+      </section>
+
+      <main id="messages" class="messages" role="log" aria-live="polite"></main>
+
+      <footer class="composer">
+        <div id="attachmentPreview" class="attachment hidden"></div>
+        <textarea id="input" placeholder="Ask anything... (Shift+Enter for newline)" rows="2"></textarea>
+        <div class="composer-actions">
+          <button id="sendBtn" class="primary">Send</button>
+        </div>
+      </footer>
+    </div>
+    <script src="sidepanel.js" type="module"></script>
+  </body>
+  </html>
+

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -1,0 +1,212 @@
+const messagesEl = document.getElementById('messages');
+const inputEl = document.getElementById('input');
+const sendBtn = document.getElementById('sendBtn');
+const screenshotBtn = document.getElementById('screenshotBtn');
+const openOptionsBtn = document.getElementById('openOptionsBtn');
+const bannerOpenOptionsBtn = document.getElementById('bannerOpenOptionsBtn');
+const apiKeyBannerEl = document.getElementById('apiKeyBanner');
+const attachmentPreviewEl = document.getElementById('attachmentPreview');
+
+let state = {
+  apiKey: null,
+  messages: [],
+  pendingAttachment: null, // { dataUrl, mime }
+  isSending: false,
+};
+
+function setBannerVisible(visible) {
+  if (visible) apiKeyBannerEl.classList.remove('hidden');
+  else apiKeyBannerEl.classList.add('hidden');
+}
+
+function renderMessages() {
+  messagesEl.innerHTML = '';
+  for (const message of state.messages) {
+    const wrapper = document.createElement('div');
+    wrapper.className = `msg ${message.role}`;
+
+    const role = document.createElement('div');
+    role.className = 'role';
+    role.textContent = message.role === 'assistant' ? 'Assistant' : 'You';
+    wrapper.appendChild(role);
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    content.textContent = message.text || '';
+    wrapper.appendChild(content);
+
+    if (Array.isArray(message.images)) {
+      for (const url of message.images) {
+        const img = document.createElement('img');
+        img.src = url;
+        img.className = 'attachment';
+        img.alt = 'attachment';
+        wrapper.appendChild(img);
+      }
+    }
+
+    messagesEl.appendChild(wrapper);
+  }
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function renderAttachmentPreview() {
+  if (!state.pendingAttachment) {
+    attachmentPreviewEl.classList.add('hidden');
+    attachmentPreviewEl.innerHTML = '';
+    return;
+  }
+  attachmentPreviewEl.classList.remove('hidden');
+  attachmentPreviewEl.innerHTML = '';
+  const img = document.createElement('img');
+  img.src = state.pendingAttachment.dataUrl;
+  img.alt = 'pending attachment';
+  const remove = document.createElement('button');
+  remove.textContent = 'Remove';
+  remove.className = 'remove';
+  remove.addEventListener('click', () => {
+    state.pendingAttachment = null;
+    renderAttachmentPreview();
+  });
+  attachmentPreviewEl.appendChild(img);
+  attachmentPreviewEl.appendChild(remove);
+}
+
+function setSending(isSending) {
+  state.isSending = isSending;
+  sendBtn.disabled = isSending || !state.apiKey;
+  inputEl.disabled = isSending;
+}
+
+async function loadState() {
+  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [] });
+  state.apiKey = stored.openai_api_key;
+  state.messages = Array.isArray(stored.chat_history) ? stored.chat_history : [];
+  setBannerVisible(!state.apiKey);
+  setSending(false);
+  renderMessages();
+}
+
+async function saveHistory() {
+  await chrome.storage.local.set({ chat_history: state.messages });
+}
+
+function buildUserContent(text, imageDataUrl) {
+  if (!imageDataUrl) return text;
+  return [
+    { type: 'text', text },
+    { type: 'image_url', image_url: { url: imageDataUrl } },
+  ];
+}
+
+async function callOpenAI(userContent) {
+  const body = {
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: 'You are a helpful assistant inside a Chrome extension side panel. Be concise.' },
+      ...state.messages.map((m) => {
+        const content = [];
+        if (m.text) content.push({ type: 'text', text: m.text });
+        if (Array.isArray(m.images)) {
+          for (const url of m.images) content.push({ type: 'image_url', image_url: { url } });
+        }
+        return { role: m.role, content: content.length ? content : m.text || '' };
+      }),
+      { role: 'user', content: userContent },
+    ],
+    temperature: 0.3,
+  };
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${state.apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`OpenAI error ${res.status}: ${errText}`);
+  }
+  const data = await res.json();
+  const choice = data.choices && data.choices[0];
+  const content = choice && choice.message && choice.message.content;
+  return typeof content === 'string' ? content : '';
+}
+
+async function onSend() {
+  const text = (inputEl.value || '').trim();
+  const hasImage = !!state.pendingAttachment;
+  if (!text && !hasImage) return;
+  if (!state.apiKey) {
+    setBannerVisible(true);
+    return;
+  }
+
+  const userMsg = { role: 'user', text, images: hasImage ? [state.pendingAttachment.dataUrl] : [] };
+  state.messages.push(userMsg);
+  state.pendingAttachment = null;
+  inputEl.value = '';
+  renderAttachmentPreview();
+  renderMessages();
+  await saveHistory();
+
+  setSending(true);
+  try {
+    const userContent = buildUserContent(text, userMsg.images[0]);
+    const replyText = await callOpenAI(userContent);
+    state.messages.push({ role: 'assistant', text: replyText });
+  } catch (err) {
+    state.messages.push({ role: 'assistant', text: `Error: ${err.message}` });
+  } finally {
+    setSending(false);
+    renderMessages();
+    await saveHistory();
+    inputEl.focus();
+  }
+}
+
+async function captureScreenshot() {
+  try {
+    const dataUrl = await new Promise((resolve, reject) => {
+      chrome.tabs.captureVisibleTab(undefined, { format: 'png' }, (res) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(res);
+      });
+    });
+    state.pendingAttachment = { dataUrl, mime: 'image/png' };
+    renderAttachmentPreview();
+  } catch (err) {
+    state.pendingAttachment = null;
+    renderAttachmentPreview();
+    state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err.message}` });
+    renderMessages();
+  }
+}
+
+openOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage());
+bannerOpenOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage());
+sendBtn.addEventListener('click', onSend);
+screenshotBtn.addEventListener('click', captureScreenshot);
+
+inputEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    onSend();
+  }
+});
+
+// Watch for API key changes from options
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  if (changes.openai_api_key) {
+    state.apiKey = changes.openai_api_key.newValue || null;
+    setBannerVisible(!state.apiKey);
+    setSending(false);
+  }
+});
+
+loadState();
+


### PR DESCRIPTION
Add a Chrome MV3 extension with a side panel for ChatGPT interaction and screenshot capture.

---
<a href="https://cursor.com/background-agent?bcId=bc-d885295f-6e71-4de6-8a10-c92d40282ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d885295f-6e71-4de6-8a10-c92d40282ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

