### PR TITLE
Continue ongoing work

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ Interact with ChatGPT from a Chrome side panel and capture screenshots to includ
 - `extension/options.html|css|js` — settings page for the OpenAI API key
 
 ## Notes
-- Screenshot capture uses a DOM-based renderer via a content script (`content/capture_dom.js`). The script is injected on demand if not present. Some pages (e.g., Chrome Web Store, `chrome://` URLs) cannot be captured due to browser restrictions and will show a friendly error.
+- Screenshot capture uses a DOM-based renderer via a content script (`content/capture_dom.js`). The script is injected on demand if not present. Some pages (e.g., Chrome Web Store, `chrome://` URLs) cannot be captured due to browser restrictions.
+- If a page is restricted, the extension will offer a screen/window/tab picker using the browser's screen capture (`getDisplayMedia`) to let you capture the visible content instead.
 - API calls are made directly to `https://api.openai.com/v1/chat/completions` using model `gpt-4o-mini`. You can change the model in `sidepanel.js`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Interact with ChatGPT from a Chrome side panel and capture screenshots to includ
 1. In the side panel, click the gear icon or go to the extension's Options page.
 2. Paste your OpenAI API key (starts with `sk-...`).
 3. Save. The key is stored via `chrome.storage.local` in your browser.
+4. Optional: Enable Sync to keep your key available across devices using `chrome.storage.sync`. You can encrypt the synced copy with a passphrase. Use the same passphrase on all devices and click "Import from Sync" on a new device.
 
 ## Usage
 - Open side panel via toolbar icon or "Ctrl+Shift+Y" (macOS: "Cmd+Shift+Y").

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Interact with ChatGPT from a Chrome side panel and capture screenshots to includ
 - `extension/options.html|css|js` — settings page for the OpenAI API key
 
 ## Notes
-- Screenshot capture uses `chrome.tabs.captureVisibleTab`. Granting `activeTab` permission allows capture of the current tab. Some pages (e.g., Chrome Web Store, chrome:// URLs) cannot be captured due to browser restrictions.
+- Screenshot capture uses a DOM-based renderer via a content script (`content/capture_dom.js`). The script is injected on demand if not present. Some pages (e.g., Chrome Web Store, `chrome://` URLs) cannot be captured due to browser restrictions and will show a friendly error.
 - API calls are made directly to `https://api.openai.com/v1/chat/completions` using model `gpt-4o-mini`. You can change the model in `sidepanel.js`.

--- a/extension/content/capture_dom.js
+++ b/extension/content/capture_dom.js
@@ -2,9 +2,13 @@
 // using an SVG foreignObject technique. This is a best-effort capture and may
 // not perfectly render cross-origin images or videos without CORS allowances.
 
-async function captureDomAsDataUrl() {
-  const width = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-  const height = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+async function captureDomAsDataUrl(maxWidth, jpegQuality) {
+  const viewportW = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+  const viewportH = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+  const targetMaxW = typeof maxWidth === 'number' && maxWidth > 0 ? maxWidth : viewportW;
+  const scale = Math.min(1, targetMaxW / viewportW);
+  const width = Math.max(1, Math.round(viewportW * scale));
+  const height = Math.max(1, Math.round(viewportH * scale));
 
   const cloned = document.documentElement.cloneNode(true);
 
@@ -41,7 +45,8 @@ async function captureDomAsDataUrl() {
     canvas.height = height;
     const ctx = canvas.getContext('2d');
     ctx.drawImage(img, 0, 0);
-    const dataUrl = canvas.toDataURL('image/png');
+    const quality = typeof jpegQuality === 'number' ? Math.max(0.3, Math.min(0.95, jpegQuality)) : 0.7;
+    const dataUrl = canvas.toDataURL('image/jpeg', quality);
     return dataUrl;
   } finally {
     URL.revokeObjectURL(url);
@@ -52,7 +57,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (!message || message.type !== 'CAPTURE_DOM_CANVAS') return;
   (async () => {
     try {
-      const dataUrl = await captureDomAsDataUrl();
+      const dataUrl = await captureDomAsDataUrl(message && message.maxWidth, message && message.jpegQuality);
       sendResponse({ ok: true, dataUrl });
     } catch (err) {
       sendResponse({ ok: false, error: err && err.message ? err.message : String(err) });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,8 @@
     "storage",
     "tabs",
     "sidePanel",
-    "activeTab"
+    "activeTab",
+    "scripting"
   ],
   "host_permissions": [
     "https://api.openai.com/*",

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,31 +1,25 @@
 :root {
-  --bg: #0c0f12;
-  --bg-elev: #11161b;
-  --text: #e8ecf1;
-  --muted: #9aa3b2;
-  --border: #1e2630;
+  --bg: #0b0b0c;
+  --bg-elev: #121214;
+  --text: #e7e7ea;
+  --muted: #a3a3ad;
+  --border: #26262b;
   --primary: #10a37f;
-  --shadow: 0 1px 2px rgba(0,0,0,0.25), 0 6px 18px rgba(0,0,0,0.25);
 }
 
 html, body { height: 100%; }
 body {
   margin: 0;
-  background: radial-gradient(1200px 600px at 50% -10%, #11161b 0%, #0c0f12 55%, #0b0d10 100%);
+  background: var(--bg);
   color: var(--text);
-  font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
-.wrap { max-width: 720px; margin: 48px auto; padding: 0 20px; }
-h1 { margin: 0 0 18px; letter-spacing: 0.2px; }
-.field { display: grid; gap: 6px; margin-bottom: 14px; }
-input { background: #0f1318; color: var(--text); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; outline: none; transition: border-color .2s ease, box-shadow .2s ease; }
-input:focus { border-color: #2a3543; box-shadow: 0 0 0 3px rgba(16,163,127,0.15); }
-.actions { display: flex; gap: 10px; }
-button { background: var(--primary); color: white; border: 1px solid rgba(0,0,0,0.2); border-radius: 10px; padding: 10px 14px; cursor: pointer; box-shadow: var(--shadow); transition: filter .15s ease, transform .08s ease; }
-button:hover { filter: brightness(1.05); }
-button:active { transform: translateY(1px); }
-button.secondary { background: rgba(255,255,255,0.03); color: var(--text); border: 1px solid var(--border); box-shadow: none; }
+.wrap { max-width: 640px; margin: 40px auto; padding: 0 16px; }
+h1 { margin: 0 0 16px; }
+.field { display: grid; gap: 6px; margin-bottom: 12px; }
+input { background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
+.actions { display: flex; gap: 8px; }
+button { background: var(--primary); color: white; border: none; border-radius: 8px; padding: 8px 12px; cursor: pointer; }
+button.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
 .hint { color: var(--muted); font-size: 12px; margin-top: 12px; }
 

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,25 +1,31 @@
 :root {
-  --bg: #0b0b0c;
-  --bg-elev: #121214;
-  --text: #e7e7ea;
-  --muted: #a3a3ad;
-  --border: #26262b;
+  --bg: #0c0f12;
+  --bg-elev: #11161b;
+  --text: #e8ecf1;
+  --muted: #9aa3b2;
+  --border: #1e2630;
   --primary: #10a37f;
+  --shadow: 0 1px 2px rgba(0,0,0,0.25), 0 6px 18px rgba(0,0,0,0.25);
 }
 
 html, body { height: 100%; }
 body {
   margin: 0;
-  background: var(--bg);
+  background: radial-gradient(1200px 600px at 50% -10%, #11161b 0%, #0c0f12 55%, #0b0d10 100%);
   color: var(--text);
-  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
-.wrap { max-width: 640px; margin: 40px auto; padding: 0 16px; }
-h1 { margin: 0 0 16px; }
-.field { display: grid; gap: 6px; margin-bottom: 12px; }
-input { background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
-.actions { display: flex; gap: 8px; }
-button { background: var(--primary); color: white; border: none; border-radius: 8px; padding: 8px 12px; cursor: pointer; }
-button.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+.wrap { max-width: 720px; margin: 48px auto; padding: 0 20px; }
+h1 { margin: 0 0 18px; letter-spacing: 0.2px; }
+.field { display: grid; gap: 6px; margin-bottom: 14px; }
+input { background: #0f1318; color: var(--text); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; outline: none; transition: border-color .2s ease, box-shadow .2s ease; }
+input:focus { border-color: #2a3543; box-shadow: 0 0 0 3px rgba(16,163,127,0.15); }
+.actions { display: flex; gap: 10px; }
+button { background: var(--primary); color: white; border: 1px solid rgba(0,0,0,0.2); border-radius: 10px; padding: 10px 14px; cursor: pointer; box-shadow: var(--shadow); transition: filter .15s ease, transform .08s ease; }
+button:hover { filter: brightness(1.05); }
+button:active { transform: translateY(1px); }
+button.secondary { background: rgba(255,255,255,0.03); color: var(--text); border: 1px solid var(--border); box-shadow: none; }
 .hint { color: var(--muted); font-size: 12px; margin-top: 12px; }
 

--- a/extension/options.html
+++ b/extension/options.html
@@ -13,11 +13,23 @@
         <span>OpenAI API Key</span>
         <input id="apiKey" type="password" placeholder="sk-..." />
       </label>
+      <label class="field">
+        <span><input id="syncEnabled" type="checkbox" /> Enable Sync Across Devices</span>
+      </label>
+      <label class="field" id="encryptRow" style="display:none;">
+        <span><input id="encryptEnabled" type="checkbox" /> Encrypt with passphrase</span>
+      </label>
+      <label class="field" id="passRow" style="display:none;">
+        <span>Passphrase (for encryption/decryption)</span>
+        <input id="passphrase" type="password" placeholder="Enter passphrase" />
+      </label>
       <div class="actions">
         <button id="saveBtn">Save</button>
         <button id="clearBtn" class="secondary">Clear</button>
+        <button id="importBtn" class="secondary">Import from Sync</button>
       </div>
       <p class="hint">Your key is stored locally via chrome.storage and never leaves your browser except requests sent directly to OpenAI.</p>
+      <p class="hint">If Sync is enabled, a copy is stored in chrome.storage.sync. You can optionally encrypt it with a passphrase. Use the same passphrase on all devices.</p>
     </div>
     <script src="options.js" type="module"></script>
   </body>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,15 +1,108 @@
 const apiKeyEl = document.getElementById('apiKey');
 const saveBtn = document.getElementById('saveBtn');
 const clearBtn = document.getElementById('clearBtn');
+const importBtn = document.getElementById('importBtn');
+const syncEnabledEl = document.getElementById('syncEnabled');
+const encryptEnabledEl = document.getElementById('encryptEnabled');
+const passphraseEl = document.getElementById('passphrase');
+const encryptRowEl = document.getElementById('encryptRow');
+const passRowEl = document.getElementById('passRow');
+
+function setUiVisibility() {
+  const syncOn = !!syncEnabledEl.checked;
+  const encOn = !!encryptEnabledEl.checked;
+  encryptRowEl.style.display = syncOn ? '' : 'none';
+  passRowEl.style.display = syncOn && encOn ? '' : 'none';
+}
+
+function toBase64(bytes) {
+  const bin = String.fromCharCode.apply(null, Array.from(new Uint8Array(bytes)));
+  return btoa(bin);
+}
+
+function fromBase64(base64) {
+  const bin = atob(base64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes.buffer;
+}
+
+async function deriveAesGcmKey(passphrase, salt, iterations) {
+  const enc = new TextEncoder();
+  const passBytes = enc.encode(passphrase);
+  const baseKey = await crypto.subtle.importKey('raw', passBytes, { name: 'PBKDF2' }, false, ['deriveKey']);
+  const key = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+  return key;
+}
+
+async function encryptStringAesGcm(plaintext, passphrase) {
+  const enc = new TextEncoder();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const iterations = 100000;
+  const key = await deriveAesGcmKey(passphrase, salt, iterations);
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc.encode(plaintext));
+  return {
+    ver: 1,
+    alg: 'AES-GCM',
+    kdf: 'PBKDF2',
+    iter: iterations,
+    salt: toBase64(salt),
+    iv: toBase64(iv),
+    enc: toBase64(ct),
+  };
+}
+
+async function decryptStringAesGcm(payload, passphrase) {
+  const dec = new TextDecoder();
+  const salt = new Uint8Array(fromBase64(payload.salt));
+  const iv = new Uint8Array(fromBase64(payload.iv));
+  const ct = fromBase64(payload.enc);
+  const iterations = payload.iter || payload.iterations || 100000;
+  const key = await deriveAesGcmKey(passphrase, salt, iterations);
+  const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct);
+  return dec.decode(pt);
+}
 
 async function load() {
-  const { openai_api_key } = await chrome.storage.local.get({ openai_api_key: '' });
+  const { openai_api_key, sync_enabled, encrypt_enabled } = await chrome.storage.local.get({ openai_api_key: '', sync_enabled: false, encrypt_enabled: false });
   apiKeyEl.value = openai_api_key || '';
+  syncEnabledEl.checked = !!sync_enabled;
+  encryptEnabledEl.checked = !!encrypt_enabled;
+  setUiVisibility();
 }
 
 async function save() {
   const key = apiKeyEl.value.trim();
-  await chrome.storage.local.set({ openai_api_key: key });
+  const syncOn = !!syncEnabledEl.checked;
+  const encOn = !!encryptEnabledEl.checked;
+  const passphrase = passphraseEl.value;
+  await chrome.storage.local.set({ openai_api_key: key, sync_enabled: syncOn, encrypt_enabled: encOn });
+
+  if (syncOn) {
+    if (encOn) {
+      if (!passphrase) {
+        alert('Enter a passphrase to encrypt the synced key.');
+        return;
+      }
+      try {
+        const payload = await encryptStringAesGcm(key, passphrase);
+        await chrome.storage.sync.set({ openai_api_key_sync: payload });
+      } catch (e) {
+        alert('Encryption failed.');
+        return;
+      }
+    } else {
+      await chrome.storage.sync.set({ openai_api_key_sync: key });
+    }
+  }
+
   alert('Saved');
 }
 
@@ -19,7 +112,43 @@ async function clearKey() {
   alert('Cleared');
 }
 
+async function importFromSync() {
+  const synced = await chrome.storage.sync.get({ openai_api_key_sync: null });
+  const value = synced.openai_api_key_sync;
+  if (!value) {
+    alert('Nothing found in Sync.');
+    return;
+  }
+  if (typeof value === 'string') {
+    apiKeyEl.value = value;
+    await chrome.storage.local.set({ openai_api_key: value });
+    alert('Imported from Sync.');
+    return;
+  }
+  if (typeof value === 'object' && value && value.enc) {
+    const passphrase = passphraseEl.value;
+    if (!passphrase) {
+      alert('Enter your passphrase to decrypt the synced key.');
+      return;
+    }
+    try {
+      const plaintext = await decryptStringAesGcm(value, passphrase);
+      apiKeyEl.value = plaintext;
+      await chrome.storage.local.set({ openai_api_key: plaintext });
+      alert('Imported and decrypted from Sync.');
+      return;
+    } catch (e) {
+      alert('Decryption failed. Check your passphrase.');
+      return;
+    }
+  }
+  alert('Unexpected Sync format.');
+}
+
 saveBtn.addEventListener('click', save);
 clearBtn.addEventListener('click', clearKey);
+importBtn.addEventListener('click', importFromSync);
+syncEnabledEl.addEventListener('change', setUiVisibility);
+encryptEnabledEl.addEventListener('change', setUiVisibility);
 load();
 

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -1,11 +1,10 @@
 :root {
-  --bg: #0c0f12;
-  --bg-elev: #11161b;
-  --text: #e8ecf1;
-  --muted: #9aa3b2;
-  --border: #1e2630;
+  --bg: #0b0b0c;
+  --bg-elev: #121214;
+  --text: #e7e7ea;
+  --muted: #a3a3ad;
+  --border: #26262b;
   --primary: #10a37f;
-  --shadow: 0 1px 2px rgba(0,0,0,0.25), 0 6px 18px rgba(0,0,0,0.25);
 }
 
 * { box-sizing: border-box; }
@@ -13,11 +12,9 @@
 html, body { height: 100%; }
 body {
   margin: 0;
-  background: radial-gradient(1200px 600px at 50% -10%, #11161b 0%, #0c0f12 55%, #0b0d10 100%);
+  background: var(--bg);
   color: var(--text);
-  font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 
 #app { display: flex; flex-direction: column; height: 100vh; }
@@ -26,71 +23,48 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 14px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border);
-  background: linear-gradient(180deg, rgba(14,18,22,0.8) 0%, rgba(14,18,22,0.6) 100%);
-  backdrop-filter: saturate(120%) blur(6px);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  box-shadow: 0 1px 0 rgba(255,255,255,0.03);
+  background: var(--bg-elev);
 }
-.sp-title { font-weight: 600; letter-spacing: 0.2px; }
+.sp-title { font-weight: 600; }
 .sp-actions { display: flex; gap: 6px; }
 .sp-actions button {
-  background: rgba(255,255,255,0.03);
+  background: transparent;
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px 10px;
+  border-radius: 6px;
+  padding: 6px 8px;
   cursor: pointer;
-  transition: border-color .2s ease, background-color .2s ease, transform .08s ease;
 }
-.sp-actions button:hover { border-color: #2a3543; background: rgba(255,255,255,0.05); }
-.sp-actions button:active { transform: translateY(1px); }
-.sp-actions button:focus-visible { outline: 2px solid color-mix(in oklab, var(--primary) 65%, white 0%); outline-offset: 2px; }
+.sp-actions button:hover { border-color: var(--muted); }
 
-.banner { display: flex; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border); background: #11171f; align-items: center; }
-.banner button { background: var(--primary); color: white; border: 1px solid rgba(0,0,0,0.2); border-radius: 8px; padding: 6px 12px; cursor: pointer; box-shadow: var(--shadow); }
-.banner button:hover { filter: brightness(1.05); }
-.banner button:active { transform: translateY(1px); }
+.banner { display: flex; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border); background: #1a1a1f; align-items: center; }
+.banner button { background: var(--primary); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
 .hidden { display: none !important; }
 
 .messages {
   flex: 1;
   overflow: auto;
-  padding: 14px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
-.msg { border: 1px solid var(--border); border-radius: 12px; padding: 10px 12px; background: var(--bg-elev); box-shadow: 0 0 0 1px rgba(255,255,255,0.02) inset; transition: border-color .2s ease, background-color .2s ease; }
-.msg.user { background: #0f1318; border-color: #283240; }
-.msg.assistant { background: #0e1513; border-color: #244e41; }
-.msg .role { font-size: 11px; letter-spacing: 0.2px; color: var(--muted); margin-bottom: 6px; text-transform: uppercase; }
-.msg.assistant .role { color: color-mix(in oklab, var(--primary) 75%, white 0%); }
-.msg .content { white-space: pre-wrap; line-height: 1.55; }
-.msg img.attachment { max-width: 100%; border-radius: 10px; border: 1px solid var(--border); margin-top: 8px; box-shadow: var(--shadow); }
+.msg { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: var(--bg-elev); }
+.msg.assistant { border-color: #224c41; }
+.msg .role { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+.msg .content { white-space: pre-wrap; }
+.msg img.attachment { max-width: 100%; border-radius: 8px; border: 1px solid var(--border); margin-top: 8px; }
 
-.composer { border-top: 1px solid var(--border); background: linear-gradient(180deg, rgba(14,18,22,0.8) 0%, rgba(14,18,22,0.6) 100%); padding: 12px; display: grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; gap: 10px; backdrop-filter: saturate(120%) blur(6px); box-shadow: 0 -1px 0 rgba(255,255,255,0.03); }
+.composer { border-top: 1px solid var(--border); background: var(--bg-elev); padding: 10px; display: grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; gap: 8px; }
 .composer #attachmentPreview { grid-column: 1 / -1; }
-.composer textarea { width: 100%; resize: none; background: #0f1318; color: var(--text); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; min-height: 44px; outline: none; transition: border-color .2s ease, box-shadow .2s ease; }
-.composer textarea::placeholder { color: #7b8696; }
-.composer textarea:focus { border-color: #2a3543; box-shadow: 0 0 0 3px rgba(16,163,127,0.15); }
+.composer textarea { width: 100%; resize: none; background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; min-height: 40px; }
 .composer .composer-actions { display: flex; align-items: center; gap: 8px; }
-.composer button.primary { background: var(--primary); border: 1px solid rgba(0,0,0,0.2); color: white; padding: 10px 14px; border-radius: 10px; cursor: pointer; box-shadow: var(--shadow); transition: filter .15s ease, transform .08s ease; }
-.composer button.primary:hover { filter: brightness(1.05); }
-.composer button.primary:active { transform: translateY(1px); }
-.composer button.primary:disabled { opacity: 0.6; cursor: not-allowed; filter: none; box-shadow: none; }
+.composer button.primary { background: var(--primary); border: none; color: white; padding: 8px 12px; border-radius: 8px; cursor: pointer; }
+.composer button.primary:disabled { opacity: 0.6; cursor: not-allowed; }
 
-.attachment { display: flex; gap: 10px; align-items: center; }
-.attachment img { max-width: 140px; border: 1px solid var(--border); border-radius: 10px; box-shadow: var(--shadow); }
-.attachment .remove { background: rgba(255,255,255,0.03); color: var(--muted); border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; cursor: pointer; transition: border-color .2s ease, background-color .2s ease; }
-.attachment .remove:hover { border-color: #2a3543; background: rgba(255,255,255,0.06); }
-
-/* Scrollbar styling */
-.messages::-webkit-scrollbar { width: 10px; }
-.messages::-webkit-scrollbar-track { background: transparent; }
-.messages::-webkit-scrollbar-thumb { background: #1a2230; border: 2px solid transparent; border-radius: 10px; background-clip: padding-box; }
-.messages::-webkit-scrollbar-thumb:hover { background: #212a39; border: 2px solid transparent; }
+.attachment { display: flex; gap: 8px; align-items: center; }
+.attachment img { max-width: 120px; border: 1px solid var(--border); border-radius: 8px; }
+.attachment .remove { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 4px 6px; cursor: pointer; }
 

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -68,6 +68,7 @@ body {
 .composer #attachmentPreview { grid-column: 1 / -1; }
 .composer textarea { width: 100%; resize: none; background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; min-height: 40px; }
 .composer .composer-actions { display: flex; align-items: center; gap: 8px; }
+.composer .composer-actions select { background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; }
 .composer button.primary { background: var(--primary); border: none; color: white; padding: 8px 12px; border-radius: 8px; cursor: pointer; }
 .composer button.primary:disabled { opacity: 0.6; cursor: not-allowed; }
 

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -75,3 +75,24 @@ body {
 .attachment img { max-width: 120px; border: 1px solid var(--border); border-radius: 8px; }
 .attachment .remove { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 4px 6px; cursor: pointer; }
 
+.cloak-tab {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 80px;
+  border-radius: 8px 0 0 8px;
+  background: #0e0e11;
+  border-left: 1px solid var(--border);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  opacity: 0.4;
+}
+.cloak-tab:hover { opacity: 0.8; }
+
+.cloak-hidden #app { opacity: 0; pointer-events: none; }
+.cloak-hidden .cloak-tab { opacity: 0.2; }
+.cloak-reveal #app { opacity: 1; pointer-events: auto; }
+

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -1,10 +1,11 @@
 :root {
-  --bg: #0b0b0c;
-  --bg-elev: #121214;
-  --text: #e7e7ea;
-  --muted: #a3a3ad;
-  --border: #26262b;
+  --bg: #0c0f12;
+  --bg-elev: #11161b;
+  --text: #e8ecf1;
+  --muted: #9aa3b2;
+  --border: #1e2630;
   --primary: #10a37f;
+  --shadow: 0 1px 2px rgba(0,0,0,0.25), 0 6px 18px rgba(0,0,0,0.25);
 }
 
 * { box-sizing: border-box; }
@@ -12,9 +13,11 @@
 html, body { height: 100%; }
 body {
   margin: 0;
-  background: var(--bg);
+  background: radial-gradient(1200px 600px at 50% -10%, #11161b 0%, #0c0f12 55%, #0b0d10 100%);
   color: var(--text);
-  font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 #app { display: flex; flex-direction: column; height: 100vh; }
@@ -23,48 +26,71 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 12px;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--border);
-  background: var(--bg-elev);
+  background: linear-gradient(180deg, rgba(14,18,22,0.8) 0%, rgba(14,18,22,0.6) 100%);
+  backdrop-filter: saturate(120%) blur(6px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.03);
 }
-.sp-title { font-weight: 600; }
+.sp-title { font-weight: 600; letter-spacing: 0.2px; }
 .sp-actions { display: flex; gap: 6px; }
 .sp-actions button {
-  background: transparent;
+  background: rgba(255,255,255,0.03);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 6px 8px;
+  border-radius: 8px;
+  padding: 6px 10px;
   cursor: pointer;
+  transition: border-color .2s ease, background-color .2s ease, transform .08s ease;
 }
-.sp-actions button:hover { border-color: var(--muted); }
+.sp-actions button:hover { border-color: #2a3543; background: rgba(255,255,255,0.05); }
+.sp-actions button:active { transform: translateY(1px); }
+.sp-actions button:focus-visible { outline: 2px solid color-mix(in oklab, var(--primary) 65%, white 0%); outline-offset: 2px; }
 
-.banner { display: flex; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border); background: #1a1a1f; align-items: center; }
-.banner button { background: var(--primary); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
+.banner { display: flex; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border); background: #11171f; align-items: center; }
+.banner button { background: var(--primary); color: white; border: 1px solid rgba(0,0,0,0.2); border-radius: 8px; padding: 6px 12px; cursor: pointer; box-shadow: var(--shadow); }
+.banner button:hover { filter: brightness(1.05); }
+.banner button:active { transform: translateY(1px); }
 .hidden { display: none !important; }
 
 .messages {
   flex: 1;
   overflow: auto;
-  padding: 12px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
-.msg { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: var(--bg-elev); }
-.msg.assistant { border-color: #224c41; }
-.msg .role { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
-.msg .content { white-space: pre-wrap; }
-.msg img.attachment { max-width: 100%; border-radius: 8px; border: 1px solid var(--border); margin-top: 8px; }
+.msg { border: 1px solid var(--border); border-radius: 12px; padding: 10px 12px; background: var(--bg-elev); box-shadow: 0 0 0 1px rgba(255,255,255,0.02) inset; transition: border-color .2s ease, background-color .2s ease; }
+.msg.user { background: #0f1318; border-color: #283240; }
+.msg.assistant { background: #0e1513; border-color: #244e41; }
+.msg .role { font-size: 11px; letter-spacing: 0.2px; color: var(--muted); margin-bottom: 6px; text-transform: uppercase; }
+.msg.assistant .role { color: color-mix(in oklab, var(--primary) 75%, white 0%); }
+.msg .content { white-space: pre-wrap; line-height: 1.55; }
+.msg img.attachment { max-width: 100%; border-radius: 10px; border: 1px solid var(--border); margin-top: 8px; box-shadow: var(--shadow); }
 
-.composer { border-top: 1px solid var(--border); background: var(--bg-elev); padding: 10px; display: grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; gap: 8px; }
+.composer { border-top: 1px solid var(--border); background: linear-gradient(180deg, rgba(14,18,22,0.8) 0%, rgba(14,18,22,0.6) 100%); padding: 12px; display: grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; gap: 10px; backdrop-filter: saturate(120%) blur(6px); box-shadow: 0 -1px 0 rgba(255,255,255,0.03); }
 .composer #attachmentPreview { grid-column: 1 / -1; }
-.composer textarea { width: 100%; resize: none; background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; min-height: 40px; }
+.composer textarea { width: 100%; resize: none; background: #0f1318; color: var(--text); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; min-height: 44px; outline: none; transition: border-color .2s ease, box-shadow .2s ease; }
+.composer textarea::placeholder { color: #7b8696; }
+.composer textarea:focus { border-color: #2a3543; box-shadow: 0 0 0 3px rgba(16,163,127,0.15); }
 .composer .composer-actions { display: flex; align-items: center; gap: 8px; }
-.composer button.primary { background: var(--primary); border: none; color: white; padding: 8px 12px; border-radius: 8px; cursor: pointer; }
-.composer button.primary:disabled { opacity: 0.6; cursor: not-allowed; }
+.composer button.primary { background: var(--primary); border: 1px solid rgba(0,0,0,0.2); color: white; padding: 10px 14px; border-radius: 10px; cursor: pointer; box-shadow: var(--shadow); transition: filter .15s ease, transform .08s ease; }
+.composer button.primary:hover { filter: brightness(1.05); }
+.composer button.primary:active { transform: translateY(1px); }
+.composer button.primary:disabled { opacity: 0.6; cursor: not-allowed; filter: none; box-shadow: none; }
 
-.attachment { display: flex; gap: 8px; align-items: center; }
-.attachment img { max-width: 120px; border: 1px solid var(--border); border-radius: 8px; }
-.attachment .remove { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 4px 6px; cursor: pointer; }
+.attachment { display: flex; gap: 10px; align-items: center; }
+.attachment img { max-width: 140px; border: 1px solid var(--border); border-radius: 10px; box-shadow: var(--shadow); }
+.attachment .remove { background: rgba(255,255,255,0.03); color: var(--muted); border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; cursor: pointer; transition: border-color .2s ease, background-color .2s ease; }
+.attachment .remove:hover { border-color: #2a3543; background: rgba(255,255,255,0.06); }
+
+/* Scrollbar styling */
+.messages::-webkit-scrollbar { width: 10px; }
+.messages::-webkit-scrollbar-track { background: transparent; }
+.messages::-webkit-scrollbar-thumb { background: #1a2230; border: 2px solid transparent; border-radius: 10px; background-clip: padding-box; }
+.messages::-webkit-scrollbar-thumb:hover { background: #212a39; border: 2px solid transparent; }
 

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -75,24 +75,5 @@ body {
 .attachment img { max-width: 120px; border: 1px solid var(--border); border-radius: 8px; }
 .attachment .remove { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 4px 6px; cursor: pointer; }
 
-.cloak-tab {
-  position: fixed;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-  width: 10px;
-  height: 80px;
-  border-radius: 8px 0 0 8px;
-  background: #0e0e11;
-  border-left: 1px solid var(--border);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-  opacity: 0.4;
-}
-.cloak-tab:hover { opacity: 0.8; }
-
-.cloak-hidden #app { opacity: 0; pointer-events: none; }
-.cloak-hidden .cloak-tab { opacity: 0.2; }
-.cloak-reveal #app { opacity: 1; pointer-events: auto; }
+/* removed cloak styles */
 

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -57,6 +57,13 @@ body {
 .msg .content { white-space: pre-wrap; }
 .msg img.attachment { max-width: 100%; border-radius: 8px; border: 1px solid var(--border); margin-top: 8px; }
 
+.sleek .messages { filter: blur(6px) brightness(0.7); pointer-events: none; }
+.sleek .composer textarea { filter: blur(2px) brightness(0.8); }
+.sleek .composer .composer-actions button { opacity: 0.7; }
+.sleek:hover .messages,
+.sleek:focus-within .messages { filter: none; pointer-events: auto; }
+.sleek-hold-reveal .messages { filter: none !important; pointer-events: auto !important; }
+
 .composer { border-top: 1px solid var(--border); background: var(--bg-elev); padding: 10px; display: grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; gap: 8px; }
 .composer #attachmentPreview { grid-column: 1 / -1; }
 .composer textarea { width: 100%; resize: none; background: #0f0f12; color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; min-height: 40px; }

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -28,6 +28,16 @@
         <div id="attachmentPreview" class="attachment hidden"></div>
         <textarea id="input" placeholder="Ask anything... (Shift+Enter for newline)" rows="2"></textarea>
         <div class="composer-actions">
+          <select id="captureMethod">
+            <option value="dom">DOM</option>
+            <option value="tab">Tab</option>
+            <option value="screen">Screen</option>
+          </select>
+          <select id="captureQuality">
+            <option value="low">Low</option>
+            <option value="medium" selected>Medium</option>
+            <option value="high">High</option>
+          </select>
           <button id="sendBtn" class="primary">Send</button>
         </div>
       </footer>

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -12,6 +12,7 @@
         <div class="sp-title">ChatGPT</div>
         <div class="sp-actions">
           <button id="sleekToggleBtn" title="Toggle Sleek Mode">🕶️</button>
+          <button id="clearChatBtn" title="Clear chat">🗑️</button>
           <button id="screenshotBtn" title="Capture screenshot">📸</button>
           <button id="openOptionsBtn" title="Open settings">⚙️</button>
         </div>

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -32,7 +32,6 @@
         </div>
       </footer>
     </div>
-    <div id="cloakTab" class="cloak-tab" title="Hold to reveal"></div>
     <script src="sidepanel.js" type="module"></script>
   </body>
   </html>

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -11,6 +11,7 @@
       <header class="sp-header">
         <div class="sp-title">ChatGPT</div>
         <div class="sp-actions">
+          <button id="sleekToggleBtn" title="Toggle Sleek Mode">🕶️</button>
           <button id="screenshotBtn" title="Capture screenshot">📸</button>
           <button id="openOptionsBtn" title="Open settings">⚙️</button>
         </div>

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -32,6 +32,7 @@
         </div>
       </footer>
     </div>
+    <div id="cloakTab" class="cloak-tab" title="Hold to reveal"></div>
     <script src="sidepanel.js" type="module"></script>
   </body>
   </html>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -7,6 +7,8 @@ const openOptionsBtn = document.getElementById('openOptionsBtn');
 const bannerOpenOptionsBtn = document.getElementById('bannerOpenOptionsBtn');
 const apiKeyBannerEl = document.getElementById('apiKeyBanner');
 const attachmentPreviewEl = document.getElementById('attachmentPreview');
+const captureMethodEl = document.getElementById('captureMethod');
+const captureQualityEl = document.getElementById('captureQuality');
 
 let state = {
   apiKey: null,
@@ -81,7 +83,7 @@ function setSending(isSending) {
 }
 
 async function loadState() {
-  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false });
+  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false, capture_method: 'dom', capture_quality: 'medium' });
   let apiKey = stored.openai_api_key;
   if (!apiKey && stored.sync_enabled) {
     // Auto-import plaintext key from sync if available
@@ -100,6 +102,9 @@ async function loadState() {
   setSending(false);
   renderMessages();
   applySleekMode();
+  // init capture prefs
+  if (captureMethodEl) captureMethodEl.value = stored.capture_method || 'dom';
+  if (captureQualityEl) captureQualityEl.value = stored.capture_quality || 'medium';
 }
 
 async function saveHistory() {
@@ -256,17 +261,23 @@ async function captureScreenshot() {
     if (!tab || typeof tab.id !== 'number') throw new Error('No active tab');
     const tabId = tab.id;
     const url = tab.url || '';
+    const method = (captureMethodEl && captureMethodEl.value) || 'dom';
+    const quality = (captureQualityEl && captureQualityEl.value) || 'medium';
+    const qualityToParams = {
+      low: { maxWidth: 960, jpegQuality: 0.55 },
+      medium: { maxWidth: 1280, jpegQuality: 0.7 },
+      high: { maxWidth: 1600, jpegQuality: 0.85 },
+    };
+    const params = qualityToParams[quality] || qualityToParams.medium;
 
     // Block restricted schemes/hosts where content scripts cannot run
     const restrictedScheme = /^(chrome:|chrome-devtools:|chrome-extension:)/i.test(url);
     const restrictedHost = /(^|\.)chrome\.google\.com$/i.test(new URL(url).hostname || '') || /(^|\.)chromewebstore\.google\.com$/i.test(new URL(url).hostname || '');
-    if (restrictedScheme || restrictedHost) {
-      throw new Error('This page cannot be captured due to browser restrictions.');
-    }
+    const isRestricted = restrictedScheme || restrictedHost;
 
     async function trySendOnce() {
       return await new Promise((resolve, reject) => {
-        chrome.tabs.sendMessage(tabId, { type: 'CAPTURE_DOM_CANVAS' }, (res) => {
+        chrome.tabs.sendMessage(tabId, { type: 'CAPTURE_DOM_CANVAS', maxWidth: params.maxWidth, jpegQuality: params.jpegQuality }, (res) => {
           if (chrome.runtime.lastError) {
             reject(chrome.runtime.lastError);
             return;
@@ -281,35 +292,59 @@ async function captureScreenshot() {
     }
 
     let dataUrl;
-    try {
-      // First try assuming the content script is already present
-      dataUrl = await trySendOnce();
-    } catch (_firstErr) {
-      // Inject content script on demand, then retry
+    if (method === 'dom') {
+      if (isRestricted) throw new Error('This page cannot be captured due to browser restrictions.');
       try {
+        // First try assuming the content script is already present
+        dataUrl = await trySendOnce();
+      } catch (_firstErr) {
+        // Inject content script on demand, then retry
         await chrome.scripting.executeScript({ target: { tabId }, files: ['content/capture_dom.js'] });
         dataUrl = await trySendOnce();
-      } catch (injectErr) {
-        throw injectErr;
       }
+    } else if (method === 'tab') {
+      // Built-in tab capture, then downscale+JPEG to reduce memory
+      const windowId = tab && tab.windowId;
+      const pngUrl = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
+      dataUrl = await downscaleDataUrl(pngUrl, params.maxWidth, params.jpegQuality);
+    } else {
+      // screen method
+      const pngUrl = await captureViaDisplayMedia();
+      dataUrl = await downscaleDataUrl(pngUrl, params.maxWidth, params.jpegQuality);
     }
 
     state.pendingAttachment = { dataUrl, mime: 'image/png' };
     renderAttachmentPreview();
   } catch (err) {
-    // As a final fallback (works on restricted pages), prompt for screen/window/tab capture
-    try {
-      const dataUrl = await captureViaDisplayMedia();
-      state.pendingAttachment = { dataUrl, mime: 'image/png' };
-      renderAttachmentPreview();
-      return;
-    } catch (fallbackErr) {
-      state.pendingAttachment = null;
-      renderAttachmentPreview();
-      state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err && err.message ? err.message : String(err)}; screen capture failed: ${fallbackErr && fallbackErr.message ? fallbackErr.message : String(fallbackErr)}` });
-      renderMessages();
-    }
+    state.pendingAttachment = null;
+    renderAttachmentPreview();
+    state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err && err.message ? err.message : String(err)}` });
+    renderMessages();
   }
+}
+
+async function downscaleDataUrl(srcDataUrl, maxWidth, jpegQuality) {
+  return await new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      try {
+        const scale = Math.min(1, (maxWidth || 1280) / img.width);
+        const w = Math.max(1, Math.round(img.width * scale));
+        const h = Math.max(1, Math.round(img.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, w, h);
+        const q = typeof jpegQuality === 'number' ? Math.max(0.3, Math.min(0.95, jpegQuality)) : 0.7;
+        resolve(canvas.toDataURL('image/jpeg', q));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    img.onerror = () => reject(new Error('Downscale failed'));
+    img.src = srcDataUrl;
+  });
 }
 
 openOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage());

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -190,10 +190,19 @@ async function captureScreenshot() {
     state.pendingAttachment = { dataUrl, mime: 'image/png' };
     renderAttachmentPreview();
   } catch (err) {
-    state.pendingAttachment = null;
-    renderAttachmentPreview();
-    state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err.message}` });
-    renderMessages();
+    // Fallback to browser-level visible tab capture
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+      const windowId = tab && tab.windowId;
+      const dataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
+      state.pendingAttachment = { dataUrl, mime: 'image/png' };
+      renderAttachmentPreview();
+    } catch (fallbackErr) {
+      state.pendingAttachment = null;
+      renderAttachmentPreview();
+      state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err.message}; fallback failed: ${fallbackErr.message}` });
+      renderMessages();
+    }
   }
 }
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -170,39 +170,55 @@ async function onSend() {
 
 async function captureScreenshot() {
   try {
-    // Prefer DOM-based capture via content script
     const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-    const tabId = tab && tab.id;
-    const dataUrl = await new Promise((resolve, reject) => {
-      if (!tabId) return reject(new Error('No active tab'));
-      chrome.tabs.sendMessage(tabId, { type: 'CAPTURE_DOM_CANVAS' }, (res) => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-          return;
-        }
-        if (!res || !res.ok) {
-          reject(new Error((res && res.error) || 'Capture failed'));
-          return;
-        }
-        resolve(res.dataUrl);
+    if (!tab || typeof tab.id !== 'number') throw new Error('No active tab');
+    const tabId = tab.id;
+    const url = tab.url || '';
+
+    // Block restricted schemes/hosts where content scripts cannot run
+    const restrictedScheme = /^(chrome:|chrome-devtools:|chrome-extension:)/i.test(url);
+    const restrictedHost = /(^|\.)chrome\.google\.com$/i.test(new URL(url).hostname || '') || /(^|\.)chromewebstore\.google\.com$/i.test(new URL(url).hostname || '');
+    if (restrictedScheme || restrictedHost) {
+      throw new Error('This page cannot be captured due to browser restrictions.');
+    }
+
+    async function trySendOnce() {
+      return await new Promise((resolve, reject) => {
+        chrome.tabs.sendMessage(tabId, { type: 'CAPTURE_DOM_CANVAS' }, (res) => {
+          if (chrome.runtime.lastError) {
+            reject(chrome.runtime.lastError);
+            return;
+          }
+          if (!res || !res.ok) {
+            reject(new Error((res && res.error) || 'Capture failed'));
+            return;
+          }
+          resolve(res.dataUrl);
+        });
       });
-    });
+    }
+
+    let dataUrl;
+    try {
+      // First try assuming the content script is already present
+      dataUrl = await trySendOnce();
+    } catch (_firstErr) {
+      // Inject content script on demand, then retry
+      try {
+        await chrome.scripting.executeScript({ target: { tabId }, files: ['content/capture_dom.js'] });
+        dataUrl = await trySendOnce();
+      } catch (injectErr) {
+        throw injectErr;
+      }
+    }
+
     state.pendingAttachment = { dataUrl, mime: 'image/png' };
     renderAttachmentPreview();
   } catch (err) {
-    // Fallback to browser-level visible tab capture
-    try {
-      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-      const windowId = tab && tab.windowId;
-      const dataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
-      state.pendingAttachment = { dataUrl, mime: 'image/png' };
-      renderAttachmentPreview();
-    } catch (fallbackErr) {
-      state.pendingAttachment = null;
-      renderAttachmentPreview();
-      state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err.message}; fallback failed: ${fallbackErr.message}` });
-      renderMessages();
-    }
+    state.pendingAttachment = null;
+    renderAttachmentPreview();
+    state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err && err.message ? err.message : String(err)}` });
+    renderMessages();
   }
 }
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2,6 +2,7 @@ const messagesEl = document.getElementById('messages');
 const inputEl = document.getElementById('input');
 const sendBtn = document.getElementById('sendBtn');
 const screenshotBtn = document.getElementById('screenshotBtn');
+const sleekToggleBtn = document.getElementById('sleekToggleBtn');
 const openOptionsBtn = document.getElementById('openOptionsBtn');
 const bannerOpenOptionsBtn = document.getElementById('bannerOpenOptionsBtn');
 const apiKeyBannerEl = document.getElementById('apiKeyBanner');
@@ -12,6 +13,7 @@ let state = {
   messages: [],
   pendingAttachment: null, // { dataUrl, mime }
   isSending: false,
+  sleekMode: false,
 };
 
 function setBannerVisible(visible) {
@@ -79,7 +81,7 @@ function setSending(isSending) {
 }
 
 async function loadState() {
-  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false });
+  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false });
   let apiKey = stored.openai_api_key;
   if (!apiKey && stored.sync_enabled) {
     // Auto-import plaintext key from sync if available
@@ -93,9 +95,11 @@ async function loadState() {
   }
   state.apiKey = apiKey;
   state.messages = Array.isArray(stored.chat_history) ? stored.chat_history : [];
+  state.sleekMode = !!stored.sleek_mode;
   setBannerVisible(!state.apiKey);
   setSending(false);
   renderMessages();
+  applySleekMode();
 }
 
 async function saveHistory() {
@@ -109,6 +113,32 @@ function buildUserContent(text, imageDataUrl) {
     { type: 'image_url', image_url: { url: imageDataUrl } },
   ];
 }
+
+function applySleekMode() {
+  if (state.sleekMode) {
+    document.body.classList.add('sleek');
+  } else {
+    document.body.classList.remove('sleek');
+  }
+}
+
+async function toggleSleekMode() {
+  state.sleekMode = !state.sleekMode;
+  applySleekMode();
+  await chrome.storage.local.set({ sleek_mode: state.sleekMode });
+}
+
+// Hold Space to temporarily reveal while pressed
+window.addEventListener('keydown', (e) => {
+  if (e.code === 'Space' && state.sleekMode) {
+    document.body.classList.add('sleek-hold-reveal');
+  }
+});
+window.addEventListener('keyup', (e) => {
+  if (e.code === 'Space' && state.sleekMode) {
+    document.body.classList.remove('sleek-hold-reveal');
+  }
+});
 
 async function captureViaDisplayMedia() {
   if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
@@ -284,6 +314,7 @@ openOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage())
 bannerOpenOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage());
 sendBtn.addEventListener('click', onSend);
 screenshotBtn.addEventListener('click', captureScreenshot);
+sleekToggleBtn.addEventListener('click', toggleSleekMode);
 
 inputEl.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) {
@@ -299,6 +330,10 @@ chrome.storage.onChanged.addListener((changes, area) => {
     state.apiKey = changes.openai_api_key.newValue || null;
     setBannerVisible(!state.apiKey);
     setSending(false);
+  }
+  if (changes.sleek_mode) {
+    state.sleekMode = !!changes.sleek_mode.newValue;
+    applySleekMode();
   }
 });
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -7,7 +7,6 @@ const openOptionsBtn = document.getElementById('openOptionsBtn');
 const bannerOpenOptionsBtn = document.getElementById('bannerOpenOptionsBtn');
 const apiKeyBannerEl = document.getElementById('apiKeyBanner');
 const attachmentPreviewEl = document.getElementById('attachmentPreview');
-const cloakTabEl = document.getElementById('cloakTab');
 
 let state = {
   apiKey: null,
@@ -15,7 +14,6 @@ let state = {
   pendingAttachment: null, // { dataUrl, mime }
   isSending: false,
   sleekMode: false,
-  cloakHidden: false,
 };
 
 function setBannerVisible(visible) {
@@ -83,7 +81,7 @@ function setSending(isSending) {
 }
 
 async function loadState() {
-  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false, cloak_hidden: false });
+  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false });
   let apiKey = stored.openai_api_key;
   if (!apiKey && stored.sync_enabled) {
     // Auto-import plaintext key from sync if available
@@ -98,12 +96,10 @@ async function loadState() {
   state.apiKey = apiKey;
   state.messages = Array.isArray(stored.chat_history) ? stored.chat_history : [];
   state.sleekMode = !!stored.sleek_mode;
-  state.cloakHidden = !!stored.cloak_hidden;
   setBannerVisible(!state.apiKey);
   setSending(false);
   renderMessages();
   applySleekMode();
-  applyCloak();
 }
 
 async function saveHistory() {
@@ -126,52 +122,7 @@ function applySleekMode() {
   }
 }
 
-function applyCloak() {
-  const body = document.body;
-  body.classList.toggle('cloak-hidden', state.cloakHidden);
-}
-
-async function toggleCloakHidden() {
-  state.cloakHidden = !state.cloakHidden;
-  applyCloak();
-  await chrome.storage.local.set({ cloak_hidden: state.cloakHidden });
-}
-
-function bindCloakEvents() {
-  if (!cloakTabEl) return;
-  let revealHeld = false;
-  let holdTimer = null;
-  const startReveal = () => {
-    revealHeld = true;
-    document.body.classList.add('cloak-reveal');
-  };
-  const stopReveal = () => {
-    revealHeld = false;
-    document.body.classList.remove('cloak-reveal');
-  };
-  cloakTabEl.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    holdTimer = setTimeout(startReveal, 100);
-  });
-  window.addEventListener('mouseup', () => {
-    if (holdTimer) clearTimeout(holdTimer);
-    stopReveal();
-  });
-  cloakTabEl.addEventListener('click', (e) => {
-    // Short click toggles cloaked state
-    toggleCloakHidden();
-  });
-  window.addEventListener('keydown', (e) => {
-    if (e.code === 'Space' && state.cloakHidden) {
-      startReveal();
-    }
-  });
-  window.addEventListener('keyup', (e) => {
-    if (e.code === 'Space' && state.cloakHidden) {
-      stopReveal();
-    }
-  });
-}
+// removed cloak helpers
 
 async function toggleSleekMode() {
   state.sleekMode = !state.sleekMode;
@@ -366,7 +317,6 @@ bannerOpenOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsP
 sendBtn.addEventListener('click', onSend);
 screenshotBtn.addEventListener('click', captureScreenshot);
 sleekToggleBtn.addEventListener('click', toggleSleekMode);
-bindCloakEvents();
 
 inputEl.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -99,6 +99,45 @@ function buildUserContent(text, imageDataUrl) {
   ];
 }
 
+async function captureViaDisplayMedia() {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+    throw new Error('Screen capture API unavailable in this context.');
+  }
+  const stream = await navigator.mediaDevices.getDisplayMedia({
+    video: { frameRate: 1 },
+    audio: false,
+  });
+  try {
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    video.muted = true;
+    video.playsInline = true;
+    await new Promise((resolve, reject) => {
+      const cleanup = () => {
+        video.onloadedmetadata = null;
+        video.oncanplay = null;
+        video.onerror = null;
+      };
+      video.onloadedmetadata = () => {
+        video.play().then(() => resolve()).catch(reject);
+      };
+      video.oncanplay = () => resolve();
+      video.onerror = () => reject(new Error('Screen capture video error'));
+    });
+    const width = video.videoWidth || 1280;
+    const height = video.videoHeight || 720;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0, width, height);
+    const dataUrl = canvas.toDataURL('image/png');
+    return dataUrl;
+  } finally {
+    stream.getTracks().forEach((t) => t.stop());
+  }
+}
+
 async function callOpenAI(userContent) {
   const body = {
     model: 'gpt-4o-mini',
@@ -215,10 +254,18 @@ async function captureScreenshot() {
     state.pendingAttachment = { dataUrl, mime: 'image/png' };
     renderAttachmentPreview();
   } catch (err) {
-    state.pendingAttachment = null;
-    renderAttachmentPreview();
-    state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err && err.message ? err.message : String(err)}` });
-    renderMessages();
+    // As a final fallback (works on restricted pages), prompt for screen/window/tab capture
+    try {
+      const dataUrl = await captureViaDisplayMedia();
+      state.pendingAttachment = { dataUrl, mime: 'image/png' };
+      renderAttachmentPreview();
+      return;
+    } catch (fallbackErr) {
+      state.pendingAttachment = null;
+      renderAttachmentPreview();
+      state.messages.push({ role: 'assistant', text: `Screenshot failed: ${err && err.message ? err.message : String(err)}; screen capture failed: ${fallbackErr && fallbackErr.message ? fallbackErr.message : String(fallbackErr)}` });
+      renderMessages();
+    }
   }
 }
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -7,6 +7,7 @@ const openOptionsBtn = document.getElementById('openOptionsBtn');
 const bannerOpenOptionsBtn = document.getElementById('bannerOpenOptionsBtn');
 const apiKeyBannerEl = document.getElementById('apiKeyBanner');
 const attachmentPreviewEl = document.getElementById('attachmentPreview');
+const cloakTabEl = document.getElementById('cloakTab');
 
 let state = {
   apiKey: null,
@@ -14,6 +15,7 @@ let state = {
   pendingAttachment: null, // { dataUrl, mime }
   isSending: false,
   sleekMode: false,
+  cloakHidden: false,
 };
 
 function setBannerVisible(visible) {
@@ -81,7 +83,7 @@ function setSending(isSending) {
 }
 
 async function loadState() {
-  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false });
+  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false, sleek_mode: false, cloak_hidden: false });
   let apiKey = stored.openai_api_key;
   if (!apiKey && stored.sync_enabled) {
     // Auto-import plaintext key from sync if available
@@ -96,10 +98,12 @@ async function loadState() {
   state.apiKey = apiKey;
   state.messages = Array.isArray(stored.chat_history) ? stored.chat_history : [];
   state.sleekMode = !!stored.sleek_mode;
+  state.cloakHidden = !!stored.cloak_hidden;
   setBannerVisible(!state.apiKey);
   setSending(false);
   renderMessages();
   applySleekMode();
+  applyCloak();
 }
 
 async function saveHistory() {
@@ -120,6 +124,53 @@ function applySleekMode() {
   } else {
     document.body.classList.remove('sleek');
   }
+}
+
+function applyCloak() {
+  const body = document.body;
+  body.classList.toggle('cloak-hidden', state.cloakHidden);
+}
+
+async function toggleCloakHidden() {
+  state.cloakHidden = !state.cloakHidden;
+  applyCloak();
+  await chrome.storage.local.set({ cloak_hidden: state.cloakHidden });
+}
+
+function bindCloakEvents() {
+  if (!cloakTabEl) return;
+  let revealHeld = false;
+  let holdTimer = null;
+  const startReveal = () => {
+    revealHeld = true;
+    document.body.classList.add('cloak-reveal');
+  };
+  const stopReveal = () => {
+    revealHeld = false;
+    document.body.classList.remove('cloak-reveal');
+  };
+  cloakTabEl.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    holdTimer = setTimeout(startReveal, 100);
+  });
+  window.addEventListener('mouseup', () => {
+    if (holdTimer) clearTimeout(holdTimer);
+    stopReveal();
+  });
+  cloakTabEl.addEventListener('click', (e) => {
+    // Short click toggles cloaked state
+    toggleCloakHidden();
+  });
+  window.addEventListener('keydown', (e) => {
+    if (e.code === 'Space' && state.cloakHidden) {
+      startReveal();
+    }
+  });
+  window.addEventListener('keyup', (e) => {
+    if (e.code === 'Space' && state.cloakHidden) {
+      stopReveal();
+    }
+  });
 }
 
 async function toggleSleekMode() {
@@ -315,6 +366,7 @@ bannerOpenOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsP
 sendBtn.addEventListener('click', onSend);
 screenshotBtn.addEventListener('click', captureScreenshot);
 sleekToggleBtn.addEventListener('click', toggleSleekMode);
+bindCloakEvents();
 
 inputEl.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -3,6 +3,7 @@ const inputEl = document.getElementById('input');
 const sendBtn = document.getElementById('sendBtn');
 const screenshotBtn = document.getElementById('screenshotBtn');
 const sleekToggleBtn = document.getElementById('sleekToggleBtn');
+const clearChatBtn = document.getElementById('clearChatBtn');
 const openOptionsBtn = document.getElementById('openOptionsBtn');
 const bannerOpenOptionsBtn = document.getElementById('bannerOpenOptionsBtn');
 const apiKeyBannerEl = document.getElementById('apiKeyBanner');
@@ -109,6 +110,14 @@ async function loadState() {
 
 async function saveHistory() {
   await chrome.storage.local.set({ chat_history: state.messages });
+}
+
+async function clearHistory() {
+  const ok = confirm('Clear chat history? This cannot be undone.');
+  if (!ok) return;
+  state.messages = [];
+  renderMessages();
+  await saveHistory();
 }
 
 function buildUserContent(text, imageDataUrl) {
@@ -352,6 +361,7 @@ bannerOpenOptionsBtn.addEventListener('click', () => chrome.runtime.openOptionsP
 sendBtn.addEventListener('click', onSend);
 screenshotBtn.addEventListener('click', captureScreenshot);
 sleekToggleBtn.addEventListener('click', toggleSleekMode);
+clearChatBtn.addEventListener('click', clearHistory);
 
 inputEl.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -79,8 +79,19 @@ function setSending(isSending) {
 }
 
 async function loadState() {
-  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [] });
-  state.apiKey = stored.openai_api_key;
+  const stored = await chrome.storage.local.get({ openai_api_key: null, chat_history: [], sync_enabled: false });
+  let apiKey = stored.openai_api_key;
+  if (!apiKey && stored.sync_enabled) {
+    // Auto-import plaintext key from sync if available
+    try {
+      const { openai_api_key_sync } = await chrome.storage.sync.get({ openai_api_key_sync: null });
+      if (typeof openai_api_key_sync === 'string' && openai_api_key_sync) {
+        apiKey = openai_api_key_sync;
+        await chrome.storage.local.set({ openai_api_key: apiKey });
+      }
+    } catch (_e) {}
+  }
+  state.apiKey = apiKey;
   state.messages = Array.isArray(stored.chat_history) ? stored.chat_history : [];
   setBannerVisible(!state.apiKey);
   setSending(false);


### PR DESCRIPTION
Add a fallback to `chrome.tabs.captureVisibleTab` for screenshot capture when the primary DOM-based method fails.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdf09756-7a9b-437d-9731-373c2a65edc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cdf09756-7a9b-437d-9731-373c2a65edc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

